### PR TITLE
Don't reinvent git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-/archive
-/changes
 /config.yml
-*.html

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "git"
+gem "twitter"
+gem "pony"
+gem "twilio-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,59 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.0.0)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
+    atomic (1.1.10)
+    builder (3.2.2)
+    crack (0.3.2)
+    faraday (0.8.7)
+      multipart-post (~> 1.1)
+    git (1.2.5)
+    httparty (0.10.2)
+      multi_json (~> 1.0)
+      multi_xml (>= 0.5.2)
+    i18n (0.6.4)
+    jwt (0.1.8)
+      multi_json (>= 1.5)
+    mail (2.5.4)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mime-types (1.23)
+    minitest (4.7.5)
+    multi_json (1.7.7)
+    multi_xml (0.5.4)
+    multipart-post (1.2.0)
+    polyglot (0.3.3)
+    pony (1.5)
+      mail (> 2.0)
+    simple_oauth (0.2.0)
+    thread_safe (0.1.0)
+      atomic
+    treetop (1.4.14)
+      polyglot
+      polyglot (>= 0.3.1)
+    twilio-rb (2.3.0)
+      activesupport (>= 3.0.0)
+      builder (>= 3.2.2)
+      crack (~> 0.3.2)
+      httparty (~> 0.10.0)
+      i18n (~> 0.5)
+      jwt (>= 0.1.3)
+    twitter (4.8.1)
+      faraday (~> 0.8, < 0.10)
+      multi_json (~> 1.0)
+      simple_oauth (~> 0.2)
+    tzinfo (0.3.37)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  git
+  pony
+  twilio-rb
+  twitter

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Since then, several other litigants (Microsoft, Google, and an unnamed "Provider
 
 #### Setup and Usage
 
-Install three Ruby gems:
+Install dependencies:
 
 ```bash
-gem install twitter pony twilio-rb
+bundle install
 ```
 
 Copy `config.yml.example` to `config.yml`, then uncomment and fill in any of the sections for `twitter`, `email`, and `twilio` (SMS) to enable those kinds of notifications. Details on enabling each of them are below.
@@ -27,12 +27,12 @@ Copy `config.yml.example` to `config.yml`, then uncomment and fill in any of the
 Once configured, run the script once to save the current state of the FISC docket (this won't send any alerts):
 
 ```bash
-ruby fisa.rb
+bundle exec ruby fisa.rb
 ```
 
-This will save a `last.html` file to disk.
+This will update `./fisa.html` and push it to GitHub, if changed.
 
-Any future executions of `fisa.rb` will check the current state of the FISC docket against `last.html`, and notify upon changes. If there are changes, the script will also copy the "before" and "after" versions of the change to a `changes` directory.
+Any future executions of `fisa.rb` will check the current state of the FISC docket against the repository, and notify upon changes. If there are changes, you can view them by viewing the diff on GitHub.
 
 #### Configuring services
 

--- a/fisa.html
+++ b/fisa.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>FISC</title>
+<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7">
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+</head>
+<body style="margin-top:0px; background:url(http://www.uscourts.gov/App_Themes/BlueAndWhite/images/common/html.gif) no-repeat #011D4D center;" >
+<table style="width:800px;margin:auto; padding-top:10px; border-collapse:collapse; ">
+  <tr>
+    <td><img src="http://www.uscourts.gov/App_Themes/BlueAndWhite/images/common/header.jpg"></td>
+  </tr>
+  
+  <tr>
+    <td style="background-color:#fff;padding:10px;">
+    	<div style="margin:30px 30px 100px 30px;">
+		<h1 style="font-family:Arial, Helvetica, sans-serif;">U.S. Foreign Intelligence Surveillance Court Public Filings</h1>
+		<h5 style="font-family:Arial, Helvetica, sans-serif;">Beginning June 2013</h5>
+		<hr style="margin: 0px 0px;">
+        <h3 style="color:#8B0B04; font-family:Arial, Helvetica, sans-serif;">Docket No. 105B(g) 07-01</h3>
+        <ul>
+            <li><a href="/uscourts/courts/fisc/105b-g-07-01-motion-130614.pdf">Provider's Unclassified Motion</a></li>
+            <li><a href="/uscourts/courts/fisc/105b-g-07-01-order-130617.pdf">Order (June 17, 2013)</a></li>
+            <li><a href="/uscourts/courts/fisc/105b-g-07-01-motion-130625.pdf">United States Response to Provider's Motion</a></li>			
+            <li><a href="/uscourts/courts/fisc/105b-g-07-01-order-130626.pdf">Order (June 26, 2013)</a></li>
+        </ul>
+		<br>
+        <h3 style="color:#8B0B04; font-family:Arial, Helvetica, sans-serif;">Case No. Misc. 13-04</h3>
+        <ul>
+            <li><a href="/uscourts/courts/fisc/misc-13-04-motion.pdf">Motion for Declaratory Judgement</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-04-order.pdf">Order</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-04-response.pdf">Response of the United States</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-04-motion-130702.pdf">Consent Motion for Extension of Time to Respond</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-04-order-130703.pdf">Order</a></li>
+        </ul>
+		<br>
+        <h3 style="color:#8B0B04; font-family:Arial, Helvetica, sans-serif;">Case No. Misc. 13-03</h3>
+        <ul>
+            <li><a href="/uscourts/courts/fisc/misc-13-03-motion.pdf">Motion for Declaratory Judgement</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-03-order.pdf">Order</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-03-certification.pdf">Certification</a></li>			
+            <li><a href="/uscourts/courts/fisc/misc-13-03-response.pdf">Response of the United States</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-03-motion-130702.pdf">Consent Motion for Extension of Time to Respond</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-03-order-130703.pdf">Order</a></li>
+        </ul>
+		<br>
+        <h3 style="color:#8B0B04; font-family:Arial, Helvetica, sans-serif;">Case No. Misc. 13-02</h3>
+        <ul>
+            <li><a href="/uscourts/courts/fisc/aclu-misc-13-02.pdf">ACLU Motion for Release of Court Records</a></li>
+			<li><a href="/uscourts/courts/fisc/aclu-briefing-order.pdf">Briefing Order</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-02-motion-for-leave.pdf">Motion for Leave to File</a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-02-brief-of-amici-curiae.pdf">Brief of <em>Amici Curiae</em></a></li>
+            <li><a href="/uscourts/courts/fisc/misc-13-02-us-opposition-130705.pdf">United States' Opposition to the Motion of the ACLU, et. al.</a></li>
+        </ul>
+		<br>
+        <h3 style="color:#8B0B04; font-family:Arial, Helvetica, sans-serif;">Case No. Misc. 13-01</h3>
+        <ul>
+			<li><a href="/uscourts/courts/fisc/misc-13-01-opinion-order.pdf">Opinion and Order</a></li>
+			<li><a href="/uscourts/courts/fisc/doj-opposition-motion.pdf">DOJ Opposition to the Motion</a></li>
+            <li><a href="/uscourts/courts/fisc/eff-bar-membership.pdf">EFF Bar Membership</a></li>
+            <li><a href="/uscourts/courts/fisc/eff-order.pdf">EFF Order</a></li>
+            <li><a href="/uscourts/courts/fisc/eff-motion.pdf">EFF Motion</a></li>
+            <li><a href="/uscourts/courts/fisc/exhibit-1.pdf">Exhibit 1</a></li>
+            <li><a href="/uscourts/courts/fisc/exhibit-2.pdf">Exhibit 2</a></li>
+        </ul>
+        </div>
+    </td>
+  </tr>
+</table>
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-16355926-1']);
+  _gaq.push(['_setDomainName', 'uscourts.gov']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+</script>
+</body>
+</html>

--- a/fisa.rb
+++ b/fisa.rb
@@ -27,7 +27,7 @@ if config['twitter']
   end
 end
 
-if @config["twillo"]
+if config["twillo"]
   Twilio::Config.setup(
     account_sid: config['twilio']['account_sid'],
     auth_token: config['twilio']['auth_token']
@@ -43,11 +43,12 @@ def check_fisa
     end
 
     return false unless changed?
+
     @git.add "fisa.html"
     @git.commit "Automated update"
     @git.push
     true
-    
+
   end
 end
 

--- a/fisa.rb
+++ b/fisa.rb
@@ -40,12 +40,14 @@ def check_fisa
     open("fisa.html", "wt") do |file|
       file.write uri.read
       file.close
-      return false unless changed?
-      @git.add "fisa.html"
-      @git.commit "Automated update"
-      @git.push
-      true
     end
+
+    return false unless changed?
+    @git.add "fisa.html"
+    @git.commit "Automated update"
+    @git.push
+    true
+    
   end
 end
 

--- a/fisa.rb
+++ b/fisa.rb
@@ -3,24 +3,20 @@
 require 'rubygems'
 require 'yaml'
 require 'fileutils'
-
-# install these 3 gems
+require 'open-uri'
 require 'twitter'
 require 'pony'
 require 'twilio-rb'
-
-
-# configuration
+require 'git'
 
 # change to current dir
 FileUtils.chdir File.dirname(__FILE__)
 
+@git = Git.open './'
+
 def config
   @config ||= YAML.load(File.read("config.yml"))
 end
-
-FileUtils.mkdir_p "changes"
-FileUtils.mkdir_p "archive"
 
 if config['twitter']
   Twitter.configure do |twitter|
@@ -31,39 +27,25 @@ if config['twitter']
   end
 end
 
-Twilio::Config.setup(
-  account_sid: config['twilio']['account_sid'],
-  auth_token: config['twilio']['auth_token']
-)
-
+if @config["twillo"]
+  Twilio::Config.setup(
+    account_sid: config['twilio']['account_sid'],
+    auth_token: config['twilio']['auth_token']
+  )
+end
 
 # check FISA court for updates, compare to last check
 def check_fisa
-  system "wget http://www.uscourts.gov/uscourts/courts/fisc/index.html --output-document=current.html"
-
-  timestamp = Time.now.strftime "%Y-%m-%d-%H%M"
-  system "cp current.html archive/#{timestamp}.html"
-
-  if File.exists?("last.html")
-    last = File.read("last.html")
-    current = File.read "current.html"
-
-    if last != current
-      # for convenience, freeze the different ones elsewhere too
-      system "cp last.html changes/#{timestamp}-last.html"
-      system "cp current.html changes/#{timestamp}-current.html"
-
-      system "mv current.html last.html"
+  open("http://www.uscourts.gov/uscourts/courts/fisc/index.html") do |uri|
+    open("fisa.html", "wt") do |file|
+      file.write uri.read
+      file.close
+      return false unless changed?
+      @git.add "fisa.html"
+      @git.commit "Automated update"
+      @git.push
       true
-    else
-      system "mv current.html last.html"
-      false
     end
-  else
-    # first run, nothing to compare to
-    puts "Initializing: just downloading data, not notifying."
-    system "mv current.html last.html"
-    false
   end
 end
 
@@ -72,10 +54,12 @@ def notify_fisa(msg)
   Twitter.update(msg) if config['twitter']
   Pony.mail(config['email'].merge(body: msg)) if config['email']
   Twilio::SMS.create(to: config['twilio']['to'], from: config['twilio']['from'], body: msg) if config['twilio']
-
   puts "Notified: #{msg}"
 end
 
+def changed?
+  @git.diff('HEAD','fisa.html').entries.length != 0
+end
 
 if check_fisa
   notify_fisa "Just updated with something! http://www.uscourts.gov/uscourts/courts/fisc/index.html"


### PR DESCRIPTION
Use Git to track changes, rather than [reinventing it](https://twitter.com/konklone/status/353960261398433793).

This not only reduces the complexity of the code, but provides for better storage and analysis of changes over time by leveraging Git's built in version tracking and diffing capabilities.

Additionally, now other users that fork the project can take advantage of past crawls or perform analysis of past changes.

Other changes:
- Fixes compatibility issue when Twillo was not configured by wrapping config in conditional block.
- Rather than listing gems in the readme, lets just go ahead and user bundler.
- Use `open-uri` rather then shelling out to `wget`
