### PR TITLE
Add Pushover Notifications Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ Go to [My Applications](https://dev.twitter.com/apps) and create a new applicati
 
 Copy the "Consumer key" and "Consumer secret" to the `consumer_key` and `consumer_secret` fields. Copy the "Access token" and "Access token secret" to the `oauth_token` and `oauth_token_secret` fields.
 
+**Pushover**
+
+[Pushover](https://pushover.net/) provides an advanced notification system for Android and iOS. The script can send updates to any of your Pushover devices. As with Twitter, you will need to tell Pushover about your application, but there will not be any delay after registering your applications which are also automatically approved.
+
+```yaml
+pushover:
+  user_key:
+  app_key:
+```
+
+To enable Pushover notifications, go to the [Pushover Dashboard](https://pushover.net/), and log in. The dashboard will show your `user_key`.
+
+After that register a new application from the [New Application Page](https://pushover.net/apps/build) by entering the name and brief description of the application. Then you copy the `app_key` field when the registration is complete.
+
 ### Todo
 
 * Possibly switch to shell-ing out to the command-line for other git commands instead of the `git` gem, which exhibits strange and uninformative behavior when pushing and pulling

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Since then, several other litigants (Microsoft, Google, and an unnamed "Provider
 Install dependencies:
 
 ```bash
-gem install git twitter pony twilio-rb
+gem install git twitter pony twilio-rb pushover
 ```
 
 Copy `config.yml.example` to `config.yml`, then uncomment and fill in any of the sections for `twitter`, `email`, and `twilio` (SMS) to enable those kinds of notifications. They're all optional. Details on enabling each of them are below.

--- a/config.yml.example
+++ b/config.yml.example
@@ -29,3 +29,8 @@
 #   auth_token:
 #   from: # registered Twilio phone number
 #   to: # your number
+
+# Uncomment and fill out this section to receive Pushover Notifications
+# pushover:
+#   user_key:
+#   app_key:

--- a/fisa.rb
+++ b/fisa.rb
@@ -94,7 +94,7 @@ def notify_fisa(long_msg, short_msg)
   Twilio::SMS.create(to: config['twilio']['to'], from: config['twilio']['from'], body: short_msg) if config['twilio']
   Pony.mail(config['email'].merge(body: long_msg)) if config['email']
   Twitter.update(long_msg) if config['twitter']
-  Pushover.notification(title: 'Update to FISA Court\'s Docket', message: long_msg, url: diff_url) if config['pushover']
+  Pushover.notification(title: short_msg, message: long_msg) if config['pushover']
 
   puts "Notified: #{long_msg}"
 end

--- a/fisa.rb
+++ b/fisa.rb
@@ -10,6 +10,7 @@ require 'git'
 require 'twitter'
 require 'pony'
 require 'twilio-rb'
+require 'pushover'
 
 # change to current dir
 FileUtils.chdir File.dirname(__FILE__)
@@ -34,6 +35,13 @@ if config['twilio']
     account_sid: config['twilio']['account_sid'],
     auth_token: config['twilio']['auth_token']
   )
+end
+
+if config['pushover']
+  Pushover.configure do |pushover|
+    pushover.user = config['pushover']['user_key']
+    pushover.token = config['pushover']['app_key']
+  end
 end
 
 # check FISA court for updates, compare to last check
@@ -86,6 +94,7 @@ def notify_fisa(long_msg, short_msg)
   Twilio::SMS.create(to: config['twilio']['to'], from: config['twilio']['from'], body: short_msg) if config['twilio']
   Pony.mail(config['email'].merge(body: long_msg)) if config['email']
   Twitter.update(long_msg) if config['twitter']
+  Pushover.notification(title: 'Update to FISA Court\'s Docket', message: long_msg, url: diff_url) if config['pushover']
 
   puts "Notified: #{long_msg}"
 end


### PR DESCRIPTION
Pushover may present an attractive option for some users because it is both free and not reliant on SMS technology (e.g., works for us internationals where twilio does not!). 

Have proposed:
- Very basic additions to the Readme detailing the Pushover setup (which takes only a few seconds).
- Very simple additions to the example conflig.yml which provide the basic fields for Pushover to work.
- The Pushover config and notification features to the script such that they should not conflict with the current running of the script.
