### PR TITLE
manage dependencies with bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /config.yml.real
 /config.yml.test
 /*.log
+.bundle
+vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'git'
+gem 'pony'
+gem 'pushover'
+gem 'twilio-rb'
+gem 'twitter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,66 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.0.0)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
+    atomic (1.1.10)
+    bini (0.7.0)
+      sys-proctable
+    builder (3.2.2)
+    faraday (0.8.8)
+      multipart-post (~> 1.2.0)
+    git (1.2.5)
+    httparty (0.11.0)
+      multi_json (~> 1.0)
+      multi_xml (>= 0.5.2)
+    i18n (0.6.4)
+    jwt (0.1.8)
+      multi_json (>= 1.5)
+    mail (2.5.4)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mime-types (1.23)
+    minitest (4.7.5)
+    multi_json (1.7.7)
+    multi_xml (0.5.4)
+    multipart-post (1.2.0)
+    polyglot (0.3.3)
+    pony (1.5)
+      mail (> 2.0)
+    pushover (1.0.0)
+      bini (= 0.7.0)
+      httparty (= 0.11.0)
+      yajl-ruby (= 1.1.0)
+    simple_oauth (0.2.0)
+    sys-proctable (0.9.3)
+    thread_safe (0.1.2)
+      atomic
+    treetop (1.4.14)
+      polyglot
+      polyglot (>= 0.3.1)
+    twilio-rb (2.2.0)
+      activesupport (>= 3.0.0)
+      builder (>= 2.1.2)
+      httparty (>= 0.6.1)
+      i18n (~> 0.5)
+      jwt (>= 0.1.3)
+    twitter (4.8.1)
+      faraday (~> 0.8, < 0.10)
+      multi_json (~> 1.0)
+      simple_oauth (~> 0.2)
+    tzinfo (0.3.37)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  git
+  pony
+  pushover
+  twilio-rb
+  twitter

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Since then, several other litigants (Microsoft, Google, and an unnamed "Provider
 Install dependencies:
 
 ```bash
-gem install git twitter pony twilio-rb pushover
+bundle install
 ```
 
 Copy `config.yml.example` to `config.yml`, then uncomment and fill in any of the sections for `twitter`, `email`, and `twilio` (SMS) to enable those kinds of notifications. They're all optional. Details on enabling each of them are below.


### PR DESCRIPTION
[Bundler](http://bundler.io) manages ruby gem dependencies, and means that you, your server, and other developers will all get the same versions of the gems you need. 

(full disclosure: I am lead developer on Bundler. but it's really helpful, I swear.)
